### PR TITLE
fix redirect loop

### DIFF
--- a/signin.html
+++ b/signin.html
@@ -42,39 +42,37 @@
 		  ],
 		});
 
-	  	firebase.auth().onAuthStateChanged(user => {
+	  	firebase.auth()
+	  	.onAuthStateChanged(user => {
 			  if(user) {
 			  	var useremail = JSON.stringify(user.email);
-			  	console.log(useremail[useremail.length-1])
-			  	if (useremail[useremail.length-8]=='@'){
-			  		if (useremail[useremail.length-7]=='d'){
-			  			if (useremail[useremail.length-6]=='h'){
-			  				if (useremail[useremail.length-5]=='s'){
-			  					if (useremail[useremail.length-4]=='.'){
-			  						if (useremail[useremail.length-3]=='s'){
-			  							if (useremail[useremail.length-2]=='g'){
-			  								if (useremail[useremail.length-1]=='"'){
-	            	localStorage.setItem("Name",user.displayName);
-	            	localStorage.setItem("Email",user.email);
-			  	}}}}}}}}
-	            // User is signed in.
-	            if (localStorage.getItem("Name")!=""){
-	            	window.location.href="./index.html";
-	            } else {
-	            	logout();
-	            	window.location.href="./signinretry.html";
-	            }
-	          } else {
-	            // User is signed out.
-	          }
-	        }, function(error) {
-	          console.log(error);
-	        });
+			  	console.log(useremail[useremail.length-1]);
+
+			  	// if the user's email ends in @dhs.sg
+			  	console.log(user.email.match(/.*@dhs\.sg$/))
+			  	if ( user.email.match(/.*@dhs\.sg$/) ) {
+			  		console.log('haha yes')
+			  		// the user's from dhs; let them in and redirect them to index.html
+          	localStorage.setItem("Name",user.displayName);
+          	localStorage.setItem("Email",user.email);
+        		window.location.href="./index.html";
+			  	} else {
+			  		// the user's not from dhs; send them back to signinretry.html
+	          logout();
+          }
+        }
+      }, function(error) {
+        console.log(error);
+      });
 
 	  	function logout(){
-		firebase.auth().signOut().then(function() {
-	  }, function(error) {});
-	}
+				firebase.auth().signOut()
+				.then(function() {
+        	window.location.href="./signinretry.html";
+			 	}, function(error) {
+
+			 	});
+			}
 
 	</script>
 	<div id="darken" onclick="hidenav()"></div>

--- a/signinretry.html
+++ b/signinretry.html
@@ -42,39 +42,37 @@
 		  ],
 		});
 
-	  	firebase.auth().onAuthStateChanged(user => {
+	  	firebase.auth()
+	  	.onAuthStateChanged(user => {
 			  if(user) {
 			  	var useremail = JSON.stringify(user.email);
-			  	console.log(useremail[useremail.length-1])
-			  	if (useremail[useremail.length-8]=='@'){
-			  		if (useremail[useremail.length-7]=='d'){
-			  			if (useremail[useremail.length-6]=='h'){
-			  				if (useremail[useremail.length-5]=='s'){
-			  					if (useremail[useremail.length-4]=='.'){
-			  						if (useremail[useremail.length-3]=='s'){
-			  							if (useremail[useremail.length-2]=='g'){
-			  								if (useremail[useremail.length-1]=='"'){
-	            	localStorage.setItem("Name",user.displayName);
-	            	localStorage.setItem("Email",user.email);
-			  	}}}}}}}}
-	            // User is signed in.
-	            if (localStorage.getItem("Name")!=""){
-	            	window.location.href="./index.html";
-	            } else {
-	            	logout();
-	            	window.location.href="./signinretry.html";
-	            }
-	          } else {
-	            // User is signed out.
-	          }
-	        }, function(error) {
-	          console.log(error);
-	        });
+			  	console.log(useremail[useremail.length-1]);
 
-function logout(){
-		firebase.auth().signOut().then(function() {
-	  }, function(error) {});
-	}
+			  	// if the user's email ends in @dhs.sg
+			  	console.log(user.email.match(/.*@dhs\.sg$/))
+			  	if ( user.email.match(/.*@dhs\.sg$/) ) {
+			  		console.log('haha yes')
+			  		// the user's from dhs; let them in and redirect them to index.html
+          	localStorage.setItem("Name",user.displayName);
+          	localStorage.setItem("Email",user.email);
+        		window.location.href="./index.html";
+			  	} else {
+			  		// the user's not from dhs; send them back to signinretry.html
+	          logout();
+          }
+        }
+      }, function(error) {
+        console.log(error);
+      });
+
+	  	function logout(){
+				firebase.auth().signOut()
+				.then(function() {
+        	window.location.href="./signinretry.html";
+			 	}, function(error) {
+
+			 	});
+			}
 
 	</script>
 	<div id="darken" onclick="hidenav()"></div>

--- a/signinretry.html
+++ b/signinretry.html
@@ -49,9 +49,7 @@
 			  	console.log(useremail[useremail.length-1]);
 
 			  	// if the user's email ends in @dhs.sg
-			  	console.log(user.email.match(/.*@dhs\.sg$/))
 			  	if ( user.email.match(/.*@dhs\.sg$/) ) {
-			  		console.log('haha yes')
 			  		// the user's from dhs; let them in and redirect them to index.html
           	localStorage.setItem("Name",user.displayName);
           	localStorage.setItem("Email",user.email);


### PR DESCRIPTION
cleaned up "@dhs.sg" matching code. also, fixed a bug where a user who signed in without a `@dhs.sg` email would get redirected back and forth between `index.html` and `signin.html`.  `signinretry.html` is now actually used for retries.

on an unrelated note, while for now the app lives completely on the frontend, it might be prudent to shift some of the authentication code to the backend. also, given that this app mostly targets students on mobile devices (i.e. limited connectivity), it might also be prudent to use Progressive Web technologies (read: caching) to help users save on data. this will probably be done at a later stage.